### PR TITLE
Return Results directly in HttpCodeHelper

### DIFF
--- a/src/ProductRegistrationSystemAPI/sharedKernel/HttpCodesHelper.cs
+++ b/src/ProductRegistrationSystemAPI/sharedKernel/HttpCodesHelper.cs
@@ -13,28 +13,20 @@ namespace sharedKernel
                 switch (res.ResponseStatusCode)
                 {
                     case System.Net.HttpStatusCode.OK:
-                        Results.Ok(res);
-                        break
-                           ;
+                        return Results.Ok(res);
                     case System.Net.HttpStatusCode.NotFound:
-                        Results.NotFound(res);
-                        break;
-
+                        return Results.NotFound(res);
                     case System.Net.HttpStatusCode.Unauthorized:
-                        Results.Unauthorized();
-                        break;
-
+                        return Results.Unauthorized();
                     case System.Net.HttpStatusCode.BadRequest:
-                        Results.BadRequest();
-                        break;
+                        return Results.BadRequest();
                     case System.Net.HttpStatusCode.Created:
-                        Results.Created("", res);
-                        break;
+                        return Results.Created("", res);
                     case System.Net.HttpStatusCode.InternalServerError:
-                        Results.Problem();
-                        break;
-                };
-                return Results.Json(res);
+                        return Results.Problem();
+                    default:
+                        return Results.Json(res);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- simplify the Response helper to directly return the desired Results

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842eb9c1c50832dad61f82768ed1cfe