### PR TITLE
Fix typos in Product BL messages

### DIFF
--- a/src/ProductRegistrationSystemAPI/businessLogic/ProductBL.cs
+++ b/src/ProductRegistrationSystemAPI/businessLogic/ProductBL.cs
@@ -70,12 +70,12 @@ namespace businessLogic
             try
             {
                 if (request.Product.ProductId != 0)
-                { 
-                   throw new ArgumentNullException("Insert product do not needs the property ProductId with value");
+                {
+                   throw new ArgumentNullException("Insert product does not need the property `ProductId` set");
                 }
 
                 long result = await _productService.Insert(request.Product);
-                string dataResult = result > 0 ? "Product has been added on database succesfully" : "Product do not added on database.";
+                string dataResult = result > 0 ? "Product has been added on database successfully" : "Product not added to database.";
                 responseMask.ResponseData = $"New id generated for added product is: {result}";
                 responseMask.ResponseStatusCode = _statusCode;
             }
@@ -95,7 +95,7 @@ namespace businessLogic
             {
 
                 bool result = await _productService.Update(request.Product, request.Id);
-                string dataResult = result ? "Product has been updated on database succesfully" : "Product do not updated on database.";
+                string dataResult = result ? "Product has been updated on database successfully" : "Product not updated in database.";
                 responseMask.ResponseData = dataResult;
                 responseMask.ResponseStatusCode = _statusCode;
             }

--- a/src/ProductRegistrationSystemAPITest/tests/ProductTest.cs
+++ b/src/ProductRegistrationSystemAPITest/tests/ProductTest.cs
@@ -174,7 +174,7 @@ namespace ProductRegistrationSystemAPITest.tests
 
 
             // Assert                  
-            Assert.IsTrue(product.ResponseData?.ToString()?.Contains("Product has been updated on database succesfully"));
+            Assert.IsTrue(product.ResponseData?.ToString()?.Contains("Product has been updated on database successfully"));
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- fix spelling in ProductBL error messages
- update related test assertion

## Testing
- `dotnet test src/ProductRegistrationSystemAPI/ProductRegistrationSystemAPI.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842eb9aa550832da119562d55a164b6